### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/supabase/functions/generate-tracker-config/index.ts
+++ b/supabase/functions/generate-tracker-config/index.ts
@@ -27,7 +27,6 @@ Deno.serve(async (req: Request) => {
 
     const GEMINI_API_KEY = Deno.env.get('GEMINI_API_KEY');
     console.log('API key present:', !!GEMINI_API_KEY);
-    console.log('API key length:', GEMINI_API_KEY?.length);
     
     if (!GEMINI_API_KEY) {
       throw new Error('GEMINI_API_KEY not configured');


### PR DESCRIPTION
Potential fix for [https://github.com/simon-lowes/baseline/security/code-scanning/1](https://github.com/simon-lowes/baseline/security/code-scanning/1)

In general, the fix is to avoid logging secrets or information derived from them (even partially, such as length or substrings) to cleartext logs. For configuration debugging, prefer logging only non-sensitive metadata (e.g., “API key configured: yes/no”) without including or inferring characteristics that meaningfully describe the secret value.

For this file, the simplest fix that preserves functionality is:
- Keep a generic presence check to help debugging (“API key configured: true/false”).
- Remove the log that reports `GEMINI_API_KEY?.length`, since it exposes a characteristic of the secret.
- Ensure we do not log the key value anywhere else.

Concretely, in `supabase/functions/generate-tracker-config/index.ts`:
- Leave `console.log('API key present:', !!GEMINI_API_KEY);` as-is (or you could slightly rephrase it, but not required).
- Delete the line `console.log('API key length:', GEMINI_API_KEY?.length);`.
No new imports or helper functions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
