### PR TITLE
chore(deps): group react and react-dom in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
 
   - package-ecosystem: "devcontainers"
     directory: "/"


### PR DESCRIPTION
## Summary
- Group react, react-dom, and their @types/* packages in .github/dependabot.yml so they are always bumped in a single PR.
- Prevents version mismatch failures (react 19.2.5 + react-dom 19.2.4 crashes React at runtime and broke the smoke test on #329 / #332).

## Test plan
- [ ] CI green
- [ ] Next react bump opens as a single grouped PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)