### PR TITLE
ci: bump smoke test Node from 20 to 22

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
Required for @supabase/supabase-js >= 2.105.x which needs native WebSocket support (Node 22+) or the `ws` package. Unblocks Dependabot PR #393.