### PR TITLE
fix(deps): add missing @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
                 "@playwright/test": "^1.60.0",
                 "@tailwindcss/postcss": "^4.3.0",
                 "@types/lz-string": "^1.5.0",
+                "@types/node": "^25.7.0",
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.0.4",
                 "@typescript-eslint/eslint-plugin": "^8.58.0",
@@ -5432,12 +5433,12 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "25.0.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.10.tgz",
-            "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
+            "version": "25.7.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+            "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.16.0"
+                "undici-types": "~7.21.0"
             }
         },
         "node_modules/@types/pako": {
@@ -11860,9 +11861,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.16.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+            "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
             "license": "MIT"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
         "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.0",
         "@types/lz-string": "^1.5.0",
+        "@types/node": "^25.7.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.0.4",
         "@typescript-eslint/eslint-plugin": "^8.58.0",


### PR DESCRIPTION
tsconfig.json declares `types: [vitest/globals, node]` but `@types/node` was missing from devDependencies. Build (`tsc -b --noCheck && vite build`) failed with TS2688.

The bug was previously masked by an earlier unit-test failure (Node 20 WebSocket issue, fixed by #409). Now exposed at the tsc step on Dependabot PR #393.