### PR TITLE
security: low-risk hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+    cooldown:
+      default-days: 5
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
 
   - package-ecosystem: "devcontainers"
     directory: "/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
                 "jspdf": "^4.2.1",
                 "lucide-react": "^1.17.0",
                 "lz-string": "^1.5.0",
-                "marked": "^18.0.4",
                 "motion-dom": "^12.40.0",
                 "next-themes": "^0.4.6",
                 "octokit": "^5.0.5",
@@ -1754,9 +1753,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1828,9 +1827,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6237,9 +6236,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -8001,9 +8000,9 @@
             }
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8081,9 +8080,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9882,18 +9881,6 @@
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
-        "node_modules/marked": {
-            "version": "18.0.4",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
-            "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
-            "license": "MIT",
-            "bin": {
-                "marked": "bin/marked.js"
-            },
-            "engines": {
-                "node": ">= 20"
-            }
-        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9928,9 +9915,9 @@
             }
         },
         "node_modules/minimatch/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
         "jspdf": "^4.2.1",
         "lucide-react": "^1.17.0",
         "lz-string": "^1.5.0",
-        "marked": "^18.0.4",
         "motion-dom": "^12.40.0",
         "next-themes": "^0.4.6",
         "octokit": "^5.0.5",


### PR DESCRIPTION
## Summary
Low-risk, minimal-diff security hardening. Three changes applied; the proposed CSP change was intentionally skipped (see below).

### 1. brace-expansion patch bump (lockfile only)
- `brace-expansion@5.0.5` (vulnerable range >=5.0.0 <5.0.6, GHSA-jxxr-4gwj-5jf2 DoS) bumped to `5.0.6` via `npm update brace-expansion`.
- `npm ls brace-expansion` confirms no copy remains in the 5.0.0–5.0.5 range. The unrelated 1.1.x and 2.x copies (different major lines) also moved to non-vulnerable patches (1.1.15, 2.1.1) as a side effect of the update — both are fine.
- Dev-only transitive dependency; non-breaking.

### 2. Remove dead `marked` dependency
- `marked` was listed in `dependencies` but is not imported anywhere in `src/` (verified: the only "marked" hit is the English word in a code comment). Removed via `npm uninstall marked`.
- `marked` is a markdown to HTML sink; removing an unused copy reduces future XSS surface.

### 3. CSP in security-headers.json — SKIPPED (intentional)
The task proposed adding a conservative CSP to `security-headers.json`. I skipped it because **it would break the SPA**:
- `index.html` already ships a full, working CSP meta tag that whitelists origins the app actually uses: `https://fonts.googleapis.com`, `https://fonts.gstatic.com`, `https://generativelanguage.googleapis.com` (Gemini), `https://api.datamuse.com`, `https://en.wikipedia.org`, plus `img-src ... blob: https:`.
- The proposed header CSP only allowed `default-src 'self'; script-src 'self'; ... connect-src 'self' https://*.supabase.co`. Browsers enforce the **intersection** of meta-tag and response-header CSPs (most restrictive wins), so this would have blocked Google Fonts and all the external APIs above, breaking the app.
- Per the task's own escape clause, I did not include a CSP I was not confident was non-breaking. If a response-header CSP is still desired, it should mirror the existing index.html policy origin-for-origin and be tested on a preview deploy first.

### 4. Dependabot cooldown
- Added a `cooldown` block (default 5d, major 7d, minor 5d, patch 3d) to the **npm** ecosystem entry only. The existing `groups: react` block and the `devcontainers` entry are unchanged.

## Verify
- `npm run build` — passes.
- `npm run lint` — 0 errors (pre-existing warnings only).
- `npm test` — 283/283 individual tests pass, including the security-headers test suite. 3 test files fail at import time due to missing `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` env vars in the CI/sandbox environment; verified identical failures on the clean main tree (pre-existing, unrelated to this PR).

## Files changed
- `package.json` (marked removed)
- `package-lock.json` (brace-expansion bump + marked removal)
- `.github/dependabot.yml` (npm cooldown)

Do not enable auto-merge.